### PR TITLE
Fixed parsing of Git user.name configuration

### DIFF
--- a/lib/rubysmith/configuration/transformers/git_user.rb
+++ b/lib/rubysmith/configuration/transformers/git_user.rb
@@ -25,7 +25,7 @@ module Rubysmith
             next content unless name
 
             first, last = String(name).split
-            content.merge! author_given_name: first, author_family_name: last
+            content.merge!(author_given_name: first, author_family_name: last).compress
           end
         end
       end

--- a/spec/lib/rubysmith/configuration/transformers/git_user_spec.rb
+++ b/spec/lib/rubysmith/configuration/transformers/git_user_spec.rb
@@ -45,5 +45,11 @@ RSpec.describe Rubysmith::Configuration::Transformers::GitUser do
       allow(git).to receive(:get).with("user.name", nil).and_return(Failure("Danger!"))
       expect(transformer.call({})).to eq(Success({}))
     end
+
+    it "answers Git name when custom user is missing and Git user exists with no family name" do
+      allow(git).to receive(:get).with("user.name", nil).and_return(Success("Git"))
+
+      expect(transformer.call({})).to eq(Success(author_given_name: "Git"))
+    end
   end
 end


### PR DESCRIPTION
## Overview
In my git config my `user.name` value is just `copiousfreetime` when this is parsed by rubysmith, it raises an error

## Screenshots/Screencasts

```
% git config --get user.name
copiousfreetime

% rubysmith -h
🔥 Unable to load configuration due to the following issues:
  - author_family_name must be filled
```

## Details

Couple of options on this, I thought maybe allowing nil for `adult_family_name` might be a way, but none of the others allowed for that, so went with eliminating `nil` as a value in the content hash.

